### PR TITLE
Fix SF63 deprecation

### DIFF
--- a/QipsiusTCPDFBundle.php
+++ b/QipsiusTCPDFBundle.php
@@ -12,7 +12,7 @@ class QipsiusTCPDFBundle extends Bundle
      * Ran on bundle boot, our TCPDF configuration constants
      * get defined here if required
      */
-    public function boot()
+    public function boot(): void
     {
         if (!$this->container->hasParameter('qipsius_tcpdf.tcpdf')) {
             return;


### PR DESCRIPTION
Add "void" return type to fix the following issue (available from PHP 7.1:

Method "Symfony\Component\HttpKernel\Bundle\Bundle::boot()" might add "void" as a native return type declaration in the future. Do the same in child class "Qipsius\TCPDFBundle\QipsiusTCPDFBundle" now to avoid errors or add an explicit @return annotation to suppress this message.
